### PR TITLE
feat: implement admin mode for clean public CV sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,23 @@
     <div class="tab-controls">
       <button onclick="setLanguage('no')" class="tab-button">Norsk</button>
       <button onclick="setLanguage('en')" class="tab-button">English</button>
-      <button onclick="setLinkMode('links')" class="tab-button" id="links-btn">
+      <button
+        onclick="setLinkMode('links')"
+        class="tab-button admin-tab"
+        id="links-btn"
+      >
         🔗 Links
       </button>
-      <button onclick="setLinkMode('qr')" class="tab-button" id="qr-btn">
+      <button
+        onclick="setLinkMode('qr')"
+        class="tab-button admin-tab"
+        id="qr-btn"
+      >
         📱 QR Codes
       </button>
       <button
         onclick="setAboutMode('application')"
-        class="tab-button"
+        class="tab-button admin-tab"
         id="application-btn"
       >
         <span data-lang="no">💼 Søknad</span>
@@ -28,13 +36,13 @@
       </button>
       <button
         onclick="setAboutMode('standard')"
-        class="tab-button"
+        class="tab-button admin-tab"
         id="standard-btn"
       >
         <span data-lang="no">📄 Standard CV</span>
         <span data-lang="en">📄 Standard CV</span>
       </button>
-      <button onclick="printCV()" class="tab-button">
+      <button onclick="printCV()" class="tab-button admin-tab">
         <span data-lang="no">📄 PDF</span>
         <span data-lang="en">📄 PDF</span>
       </button>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,22 @@ let currentLanguage = "no";
 let printModal;
 let currentLinkMode = "links"; // "links" or "qr"
 let currentAboutMode = "application"; // "application" or "standard"
+let isAdminMode = false; // Admin mode state
+
+// Check if admin mode is enabled via URL parameter
+function checkAdminMode() {
+  const urlParams = new URLSearchParams(window.location.search);
+  isAdminMode = urlParams.get("admin") === "true";
+  toggleAdminTabs();
+}
+
+// Show/hide admin-only tabs based on admin mode
+function toggleAdminTabs() {
+  const adminTabs = document.querySelectorAll(".admin-tab");
+  adminTabs.forEach((tab) => {
+    tab.style.display = isAdminMode ? "" : "none";
+  });
+}
 
 // Language switching functionality
 function setLanguage(lang) {
@@ -158,6 +174,9 @@ function hideModal() {
 window.addEventListener("DOMContentLoaded", () => {
   // Initialize DOM references
   printModal = document.getElementById("printModal");
+
+  // Check admin mode from URL
+  checkAdminMode();
 
   // Auto-detect browser language and set active button
   const preferred = navigator.language.startsWith("no") ? "no" : "en";


### PR DESCRIPTION
Gotten so much confusing and varying feedback from peers when showing my CV site. Figured a simple language toggle is all the public CV needs, and every other options i have made can just be for me (adminmode)

Maybe not the cleanest version of an admin mode, but it works, and adds no confusing UI elements. Just URL parameter for me to know. 